### PR TITLE
Remove test error and replace with Sentry test button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,10 +28,8 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
-      <button onClick={
-          () => {throw new Error("This is your first error!");}
-        }>
-        Break the world
+      <button onClick={() => console.log('Hello from Sentry!')}>
+        Test Sentry
       </button>
     </>
   )


### PR DESCRIPTION
This PR removes the intentional test error that was causing Sentry issues and replaces it with a more appropriate test button that logs to the console instead of throwing an error.

Changes made:
- Removed the "Break the world" button that was throwing a test error
- Added a "Test Sentry" button that logs to the console instead
- Maintains Sentry integration while removing the test error